### PR TITLE
Remove dependency on Handler from Storage

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -16,3 +16,4 @@
 :set -XTupleSections
 :set -XTypeFamilies
 :set -XViewPatterns
+:set -XRankNTypes

--- a/circle.yml
+++ b/circle.yml
@@ -2,9 +2,9 @@ dependencies:
   cache_directories:
     - "~/.stack"
   pre:
-    - wget https://github.com/commercialhaskell/stack/releases/download/v0.1.2.0/stack-0.1.2.0-x86_64-linux.gz -O /tmp/stack.gz
-    - gunzip /tmp/stack.gz && chmod +x /tmp/stack
-    - sudo mv /tmp/stack /usr/bin/stack
+    - wget https://github.com/commercialhaskell/stack/releases/download/v0.1.6.0/stack-0.1.6.0-linux-x86_64.tar.gz -O /tmp/stack.tar.gz
+    - tar xvzOf /tmp/stack.tar.gz stack-0.1.6.0-linux-x86_64/stack > /tmp/stack
+    - chmod +x /tmp/stack && sudo mv /tmp/stack /usr/bin/stack
   override:
     - stack setup
     - stack build

--- a/src/Handler/Command.hs
+++ b/src/Handler/Command.hs
@@ -40,10 +40,9 @@ patchCommandR :: Token -> Handler ()
 patchCommandR token = do
     now <- liftIO getCurrentTime
     req <- requireJsonBody
+    command <- get404 token
 
     unsafeRunStorage $ do
-        command <- get404 token
-
         let running = fromMaybe (commandRunning command) $ reqRunning req
             description = maybe (commandDescription command) Just $ reqDescription req
 
@@ -55,7 +54,7 @@ patchCommandR token = do
 
 getCommandR :: Token -> Handler TypedContent
 getCommandR token = do
-    command <- unsafeRunStorage $ get404 token
+    command <- get404 token
 
     selectRep $ do
         provideRep $ return $ toJSON command

--- a/src/Import/NoFoundation.hs
+++ b/src/Import/NoFoundation.hs
@@ -2,7 +2,7 @@ module Import.NoFoundation
     ( module Import
     ) where
 
-import ClassyPrelude.Yesod   as Import hiding (get404)
+import ClassyPrelude.Yesod   as Import hiding (get, get404)
 import Data.Aeson            as Import
 import Model                 as Import
 import Settings              as Import

--- a/tee-io.cabal
+++ b/tee-io.cabal
@@ -50,6 +50,7 @@ library
                 ViewPatterns
                 TupleSections
                 RecordWildCards
+                RankNTypes
 
     build-depends: base                          >= 4          && < 5
                  , yesod                         >= 1.4.1      && < 1.5
@@ -122,6 +123,7 @@ test-suite test
                 ViewPatterns
                 TupleSections
                 RecordWildCards
+                RankNTypes
 
     build-depends: base
                  , tee-io

--- a/test/Handler/CommandSpec.hs
+++ b/test/Handler/CommandSpec.hs
@@ -21,7 +21,7 @@ spec = withApp $ do
             postJSON CommandsR $ object []
 
             withJSONResponse $ \(Response token) -> do
-                command <- runStorage' $ get404 token
+                command <- getCommand token
                 commandRunning command `shouldBe` True
                 commandDescription command `shouldBe` Nothing
 
@@ -29,7 +29,7 @@ spec = withApp $ do
             postJSON CommandsR $ object ["description" .= ("test command" :: Text)]
 
             withJSONResponse $ \(Response token) -> do
-                command <- runStorage' $ get404 token
+                command <- getCommand token
                 commandRunning command `shouldBe` True
                 commandDescription command `shouldBe` Just "test command"
 
@@ -46,7 +46,7 @@ spec = withApp $ do
 
             patchJSON (CommandR token) $ object ["running" .= False]
 
-            updated <- runStorage' $ get404 token
+            updated <- getCommand token
             commandRunning updated `shouldBe` False
             commandDescription updated `shouldBe` Just "a description"
             commandUpdatedAt updated `shouldSatisfy` (not . (== now))


### PR DESCRIPTION
- Quantify Storage over any (MonadIO m)
- Hoist unsafeRunStorage and get404 out to Foundation, still available
  everywhere, but more closely coupled to Handler itself

This makes the test suite a bit cleaner (no use of the unsafe handler function)
and paves the way for a worker process that doesn't live itself have to live in
Handler (IO will be enough).

Moving unsafeRunStorage out another layer of abstraction is also good as the
only reason this "unsafe" function is safe where it's used is that, in the
context of a Handler, an unchecked exception is actually the desired result
(i.e. a 500 and error message) when a storage operation fails.

Moving get404 also makes sense as having the Storage layer know how to render a
404, while convenient, is not an elegant pattern to copy from Persistent IMHO.
