### PR TITLE
Simplify database configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,10 +12,10 @@ dependencies:
     - chmod +x /tmp/stack && sudo mv /tmp/stack /usr/bin/stack
   override:
     - stack setup
-    - stack build --ghc-options -DDEVELOPMENT
+    - stack build
 
 test:
   pre:
     - bin/setup
   override:
-    - stack test --ghc-options -DDEVELOPMENT
+    - stack test

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,9 @@ ip-from-header:  "_env:IP_FROM_HEADER:false"
 command-timeout: "_env:COMMAND_TIMEOUT:300"
 s3-bucket:       "_env:S3_BUCKET:tee.io.development"
 
+database-url:       "_env:DATABASE_URL:postgres://teeio:teeio@localhost:5432/teeio"
+database-pool-size: "_env:PGPOOLSIZE:10" # use conventional variable
+
 # Optional values with the following production defaults.
 # In development, they default to the inverse.
 #
@@ -18,13 +21,3 @@ s3-bucket:       "_env:S3_BUCKET:tee.io.development"
 # reload-templates: false
 # mutable-static: false
 # skip-combining: false
-#
-# database-url: true
-
-database:
-  user:     "_env:PGUSER:teeio"
-  password: "_env:PGPASS:teeio"
-  host:     "_env:PGHOST:localhost"
-  port:     "_env:PGPORT:5432"
-  database: "_env:PGDATABASE:teeio"
-  poolsize: "_env:PGPOOLSIZE:10"

--- a/config/test-settings.yml
+++ b/config/test-settings.yml
@@ -1,3 +1,2 @@
 should-log-all: false
-database:
-  database: teeio_test
+database-url: "postgres://teeio:teeio@localhost:5432/teeio_test"

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,6 @@ extra-deps:
 - amazonka-core-1.3.6
 - amazonka-s3-1.3.6
 - heroku-0.1.2.3
-- heroku-persistent-0.1.0
 - hspec-expectations-lifted-0.5.0
 - load-env-0.1.1
 - retry-0.7.0.1

--- a/tee-io.cabal
+++ b/tee-io.cabal
@@ -87,7 +87,7 @@ library
                  , yesod-websockets
                  , persistent
                  , persistent-postgresql
-                 , heroku-persistent
+                 , heroku
                  , websockets
                  , amazonka >= 1.3.5
                  , amazonka-s3


### PR DESCRIPTION
- Always use DATABASE_URL, with defaults for development and test
- Continue to use PGPOOLSIZE for variable not conveyed via URL
- -DDEVELOPMENT no longer meaningfully changes the program
