### PR TITLE
Use Fake S3 for specs

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,4 @@
-# Dummy values to avoid auth errors booting. Specs don't actually talk to AWS
-# (yet, eventually we should bring in fake-s3 and test that behavior)
 AWS_ACCESS_KEY_ID=x
 AWS_SECRET_ACCESS_KEY=x
 DATABASE_URL=postgres://teeio:teeio@localhost:5432/teeio_test
+S3_URL=http://localhost:4569/tee.io.test

--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,4 @@
 # (yet, eventually we should bring in fake-s3 and test that behavior)
 AWS_ACCESS_KEY_ID=x
 AWS_SECRET_ACCESS_KEY=x
+DATABASE_URL=postgres://teeio:teeio@localhost:5432/teeio_test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test
+
+test:
+	@docker stop tee-io-fake-s3 || true
+	@docker rm tee-io-fake-s3 || true
+	docker run \
+	  --detach \
+	  --name tee-io-fake-s3 \
+	  --publish 4569:4569 \
+	  lphoward/fake-s3
+	stack test
+	@docker stop tee-io-fake-s3 || true
+	@docker rm tee-io-fake-s3 || true

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+  services:
+    - docker
+
 dependencies:
   cache_directories:
     - "~/.stack"
@@ -13,4 +17,4 @@ test:
   pre:
     - bin/setup
   override:
-    - stack test
+    - make test

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,7 +7,7 @@ port:            "_env:PORT:3000"
 approot:         "_env:APPROOT:http://localhost:3000"
 ip-from-header:  "_env:IP_FROM_HEADER:false"
 command-timeout: "_env:COMMAND_TIMEOUT:300"
-s3-bucket:       "_env:S3_BUCKET:tee.io.development"
+s3-url:          "_env:S3_URL:https://s3.amazonaws.com/tee.io.development"
 debug:           "_env:DEBUG:false"
 
 database-url:       "_env:DATABASE_URL:postgres://teeio:teeio@localhost:5432/teeio"

--- a/config/test-settings.yml
+++ b/config/test-settings.yml
@@ -1,1 +1,0 @@
-database-url: "postgres://teeio:teeio@localhost:5432/teeio_test"

--- a/src/Application.hs
+++ b/src/Application.hs
@@ -53,11 +53,6 @@ mkYesodDispatch "App" resourcesApp
 -- migrations handled by Yesod.
 makeFoundation :: AppSettings -> IO App
 makeFoundation appSettings = do
-    when (appDebug appSettings) $ do
-        putStrLn "=== App Settings ==="
-        print appSettings
-        putStrLn "=== App Settings ==="
-
     -- Some basic initializations: HTTP connection manager, logger, and static
     -- subsite.
     appAWSEnv <- newAWSEnv $ appDebug appSettings

--- a/src/Application.hs
+++ b/src/Application.hs
@@ -83,7 +83,7 @@ makeFoundation appSettings = do
     return $ mkFoundation pool
 
   where
-    newAWSEnv debug = do
+    newAWSEnv debug = AWS.configure (appS3Service appSettings) <$> do
         logger <- AWS.newLogger (if debug then AWS.Debug else AWS.Error) stdout
         set AWS.envLogger logger <$> AWS.newEnv AWS.NorthVirginia AWS.Discover
 

--- a/src/Network/S3URL.hs
+++ b/src/Network/S3URL.hs
@@ -1,0 +1,62 @@
+module Network.S3URL
+    ( S3URL(..)
+    , parseS3URL
+    ) where
+
+import Prelude
+
+import Data.Aeson
+import Data.Text (Text)
+import Data.Maybe (fromMaybe)
+import Data.Monoid ((<>))
+import Control.Lens (view)
+import Network.URI
+import Text.Read (readMaybe)
+import Network.AWS (Region(..), Service, endpointHost)
+import Network.AWS.Endpoint (defaultEndpoint, setEndpoint)
+import Network.AWS.S3 (BucketName(..), s3)
+
+import qualified Data.ByteString.Char8 as C8
+import qualified Data.Text as T
+
+data S3URL = S3URL
+    { s3Service :: Service
+    , s3Bucket :: BucketName
+    }
+
+instance FromJSON S3URL where
+    parseJSON = withText "URL" $
+        either (fail . ("Invalid S3 URL: " <>)) return . parseS3URL
+
+parseS3URL :: Text -> Either String S3URL
+parseS3URL t = do
+    uri <- wrap "invalid URI" $ parseURI $ T.unpack t
+
+    let auth = fromMaybe (URIAuth "" "" "") $ uriAuthority uri
+        host = C8.pack $ if null $ uriRegName auth
+            then defaultS3Host
+            else uriRegName auth
+
+    port <- case uriPort auth of
+        (':':x) -> wrap "invalid port" $ readMaybe x
+        _ -> wrap "cannot infer port" $ portForScheme $ uriScheme uri
+
+    bucket <- wrap "bucket not provided" $ case uriPath uri of
+        ('/':x:xs) -> Just $ x:xs
+        _ -> Nothing
+
+    return S3URL
+        { s3Service = setEndpoint (uriScheme uri == "https:") host port s3
+        , s3Bucket = BucketName $ T.pack bucket
+        }
+
+  where
+    wrap msg = maybe (Left msg) Right
+
+    defaultS3Host = C8.unpack
+        $ view endpointHost
+        $ defaultEndpoint s3 NorthVirginia
+
+    portForScheme "http:" = Just 80
+    portForScheme "https:" = Just 443
+    portForScheme _ = Nothing

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -52,7 +52,6 @@ data AppSettings = AppSettings
     , appSkipCombining          :: Bool
     -- ^ Perform no stylesheet/script combining
     }
-    deriving Show
 
 instance FromJSON AppSettings where
     parseJSON = withObject "AppSettings" $ \o -> do

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -14,8 +14,10 @@ import Data.Time.Units             (Second)
 import Data.Yaml                   (decodeEither')
 import Database.Persist.Postgresql (PostgresConf(..))
 import Language.Haskell.TH.Syntax  (Exp, Name, Q)
-import Network.AWS.S3              (BucketName(..))
+import Network.AWS                 (Service)
+import Network.AWS.S3              (BucketName)
 import Network.Wai.Handler.Warp    (HostPreference)
+import Network.S3URL               (S3URL(..))
 import Yesod.Default.Config2       (applyEnvValue, configSettingsYml)
 import Yesod.Default.Util          (WidgetFileSettings, widgetFileNoReload,
                                     widgetFileReload)
@@ -40,6 +42,8 @@ data AppSettings = AppSettings
     -- behind a reverse proxy.
     , appCommandTimeout         :: Second
     -- ^ How long to consider a command no longer running in seconds
+    , appS3Service              :: Service
+    -- ^ S3 service to archive commands to (testing override)
     , appS3Bucket               :: BucketName
     -- ^ S3 bucket to archive commands to
     , appDebug                  :: Bool
@@ -70,7 +74,7 @@ instance FromJSON AppSettings where
         appPort                   <- o .: "port"
         appIpFromHeader           <- o .: "ip-from-header"
         appCommandTimeout         <- toSecond <$> o .: "command-timeout"
-        appS3Bucket               <- BucketName <$> o .: "s3-bucket"
+        S3URL appS3Service appS3Bucket <- o .: "s3-url"
         appDebug                  <- o .: "debug"
 
         appReloadTemplates        <- o .:? "reload-templates" .!= defaultDev

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.0
+resolver: lts-5.11
 packages:
 - '.'
 extra-deps:

--- a/tee-io.cabal
+++ b/tee-io.cabal
@@ -14,6 +14,7 @@ Flag library-only
 library
     hs-source-dirs: src, app
     exposed-modules: Data.Time.Duration
+                     Network.S3URL
                      Application
                      Foundation
                      Import
@@ -94,6 +95,7 @@ library
                  , heroku
                  , websockets
                  , amazonka >= 1.3.5
+                 , amazonka-core
                  , amazonka-s3
                  , lens
                  , http-types
@@ -102,6 +104,7 @@ library
                  , time-units
                  , scientific
                  , esqueleto
+                 , network-uri
 
 executable         tee-io
     if flag(library-only)
@@ -162,3 +165,7 @@ test-suite test
                  , persistent
                  , uuid
                  , load-env
+                 , amazonka
+                 , amazonka-s3
+                 , bytestring
+                 , lens

--- a/test/Handler/CommandSpec.hs
+++ b/test/Handler/CommandSpec.hs
@@ -35,19 +35,19 @@ spec = withApp $ do
                 Entity _ command <- runDB $ getBy404 $ UniqueCommand token
                 commandDescription command `shouldBe` Just "test command"
 
-    -- describe "DELETE /commands/token" $
-    --     it "deletes the command's data" $ do
-    --         now <- liftIO getCurrentTime
-    --         token <- newToken
-    --         void $ runDB $ insert Command
-    --             { commandToken = token
-    --             , commandRunning = True
-    --             , commandDescription = Just "a description"
-    --             , commandCreatedAt = now
-    --             }
+    describe "DELETE /commands/token" $
+        it "deletes the command's data" $ do
+            now <- liftIO getCurrentTime
+            token <- newToken
+            void $ runDB $ insert Command
+                { commandToken = token
+                , commandRunning = True
+                , commandDescription = Just "a description"
+                , commandCreatedAt = now
+                }
 
-    --         delete $ CommandR token
-    --         statusIs 200
+            delete $ CommandR token
+            statusIs 200
 
-    --         results <- runDB $ selectList [CommandToken ==. token] []
-    --         results `shouldBe` []
+            results <- runDB $ selectList [CommandToken ==. token] []
+            results `shouldBe` []

--- a/test/Network/S3URLSpec.hs
+++ b/test/Network/S3URLSpec.hs
@@ -1,0 +1,77 @@
+module Network.S3URLSpec
+    ( main
+    , spec
+    ) where
+
+import Prelude
+
+import Control.Lens
+import Data.Aeson
+import Data.Monoid ((<>))
+import Network.S3URL
+import Network.AWS
+    ( Endpoint
+    , Region(..)
+    , _svcEndpoint
+    , endpointHost
+    , endpointPort
+    , endpointSecure
+    )
+import Network.AWS.S3 (BucketName(..))
+import Test.Hspec
+
+import qualified Data.ByteString.Lazy.Char8 as C8
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = describe "S3URL" $ do
+    it "parses from JSON" $
+        withDecoded "http://localhost:4569/my-bucket" $ \url -> do
+            let ep = serviceEndpoint url
+
+            view endpointSecure ep `shouldBe` False
+            view endpointHost ep `shouldBe` "localhost"
+            view endpointPort ep `shouldBe` 4569
+
+            s3Bucket url `shouldBe` BucketName "my-bucket"
+
+    it "parses from JSON without authority" $
+        withDecoded "http:///my-bucket" $ \url -> do
+            let ep = serviceEndpoint url
+
+            view endpointSecure ep `shouldBe` False
+            view endpointHost ep `shouldBe` "s3.amazonaws.com"
+            view endpointPort ep `shouldBe` 80
+
+            s3Bucket url `shouldBe` BucketName "my-bucket"
+
+    it "parses from JSON without port" $
+        withDecoded "https://localhost/my-bucket" $ \url -> do
+            let ep = serviceEndpoint url
+
+            view endpointSecure ep `shouldBe` True
+            view endpointHost ep `shouldBe` "localhost"
+            view endpointPort ep `shouldBe` 443
+
+    it "has nice parse errors" $ do
+        let Left err1 = eitherDecode "\"ftp://invalid\"" :: Either String S3URL
+        let Left err2 = eitherDecode "\"https://localhost\"" :: Either String S3URL
+
+        err1 `shouldBe` "Invalid S3 URL: cannot infer port"
+        err2 `shouldBe` "Invalid S3 URL: bucket not provided"
+
+serviceEndpoint :: S3URL -> Endpoint
+serviceEndpoint url = _svcEndpoint (s3Service url) NorthVirginia
+
+withDecoded :: String -> (S3URL -> Expectation) -> Expectation
+withDecoded str ex = either failure ex decoded
+
+  where
+    decoded = eitherDecode $ C8.pack $ "\"" <> str <> "\""
+
+    failure err = expectationFailure $ unlines
+        [ "Expected " <> str <> " to parse as JSON"
+        , "Error: " <> err
+        ]

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -21,7 +21,7 @@ import Test.Hspec            as X hiding
     , shouldReturn
     )
 import Test.Hspec.Expectations.Lifted as X
-import Yesod.Default.Config2 (ignoreEnv, loadAppSettings)
+import Yesod.Default.Config2 (useEnv, loadAppSettings)
 import Yesod.Persist         as X (getBy404)
 import Yesod.Test            as X
 
@@ -34,9 +34,9 @@ withApp = before $ do
     loadEnvFrom ".env.test"
 
     settings <- loadAppSettings
-        ["config/test-settings.yml", "config/settings.yml"]
+        ["config/settings.yml"]
         []
-        ignoreEnv
+        useEnv
 
     app <- makeFoundation settings
     wipeDB app


### PR DESCRIPTION
Allowed us to un-comment the DELETE spec since letting it talk to S3 is now
safe in tests. I'll follow up soon with additional specs actually covering the
S3 interactions.
- Fix a bug in env.test loading
- Change how we configure AWS (create Network.URL)
- Specify S3 as localhost in .env.test
- Wrap it all up in make test
